### PR TITLE
Don't fire close event after click

### DIFF
--- a/index.js
+++ b/index.js
@@ -297,13 +297,14 @@ function buildCloseNotification(notificationWindow, notificationObj, getTimeoutI
       closedNotifications[notificationObj.id] = true
     }
 
-    if (notificationWindow.electronNotifyOnCloseFunc) {
+    if (notificationWindow.electronNotifyOnCloseFunc && !notificationWindow.clickFunctionFired) {
       notificationWindow.electronNotifyOnCloseFunc({
         event: event,
         id: notificationObj.id
       })
       delete notificationWindow.electronNotifyOnCloseFunc
     }
+    delete notificationWindow.clickFunctionFired
 
     // reset content
     notificationWindow.webContents.send('electron-notify-reset')
@@ -351,6 +352,7 @@ ipc.on('electron-notify-click', function (event, winId, notificationObj) {
   }
   let notificationWindow = BrowserWindow.fromId(winId)
   if (notificationWindow && notificationWindow.electronNotifyOnClickFunc) {
+    notificationWindow.clickFunctionFired = true
     let closeFunc = buildCloseNotification(notificationWindow, notificationObj)
     notificationWindow.electronNotifyOnClickFunc({
       event: 'click',


### PR DESCRIPTION
Don't fire close event when the notification times out after the click event has been fired.