### PR TITLE
Updated to use remote Browser Window and ipcRenderer

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ const _ = require('lodash')
 const path = require('path')
 const async = require('async')
 const electron = require('electron')
-const BrowserWindow = electron.BrowserWindow
-const ipc = electron.ipcMain
+const BrowserWindow = electron.BrowserWindow || electron.remote.BrowserWindow
+const ipc = electron.ipcMain || electron.ipcRenderer
 
 // One animation at a time
 const AnimationQueue = function(options) {


### PR DESCRIPTION
When used from the renderer process I get all kinds of errors about Browser Window not being defined. This seems to fix it all.