### PR TITLE
Fixing Close after OnClick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 npm-debug.log
 .DS_Store
 *.lnk
+.idea/
+package-lock.json

--- a/animation.css
+++ b/animation.css
@@ -1,0 +1,22 @@
+@keyframes pulse_animation {
+	0% { transform: scale(1); }
+	30% { transform: scale(1); }
+	40% { transform: scale(2.08); }
+	50% { transform: scale(1); }
+	60% { transform: scale(1); }
+	70% { transform: scale(2.05); }
+	80% { transform: scale(1); }
+	100% { transform: scale(1); }
+}
+
+.pulse {
+	animation-name: pulse_animation;
+	animation-duration: 5000ms;
+	transform-origin:70% 70%;
+	animation-iteration-count: infinite;
+	animation-timing-function: linear;
+}
+
+#body-top{
+    border-radius: 300px;
+}

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ const _ = require('lodash')
 const path = require('path')
 const async = require('async')
 const electron = require('electron')
-const BrowserWindow = electron.BrowserWindow
-const ipc = electron.ipcMain
+const BrowserWindow = electron.BrowserWindow || electron.remote.BrowserWindow
+const ipc = electron.ipcMain || electron.ipcRenderer
 
 // One animation at a time
 const AnimationQueue = function(options) {

--- a/index.js
+++ b/index.js
@@ -108,10 +108,10 @@ let config = {
   },
   htmlTemplate: '<html>\n'
   + '<head></head>\n'
-  + '<body style="overflow: hidden; -webkit-user-select: none;">\n'
+  + '<body style="overflow: hidden; -webkit-user-select: none;" id="body-top">\n'
   + '<div id="container">\n'
-  + ' <img src="" id="appIcon" />\n'
-  + ' <img src="" id="image" />\n'
+  + ' <img src="" id="appIcon"/>\n'
+  + ' <img src="" id="image" class="pulse"/>\n'
   + ' <div id="text">\n'
   + '   <b id="title"></b>\n'
   + '   <p id="message"></p>\n'

--- a/index.js
+++ b/index.js
@@ -297,14 +297,13 @@ function buildCloseNotification(notificationWindow, notificationObj, getTimeoutI
       closedNotifications[notificationObj.id] = true
     }
 
-    if (notificationWindow.electronNotifyOnCloseFunc && !notificationWindow.clickFunctionFired) {
+    if (notificationWindow.electronNotifyOnCloseFunc) {
       notificationWindow.electronNotifyOnCloseFunc({
         event: event,
         id: notificationObj.id
       })
       delete notificationWindow.electronNotifyOnCloseFunc
     }
-    delete notificationWindow.clickFunctionFired
 
     // reset content
     notificationWindow.webContents.send('electron-notify-reset')
@@ -352,7 +351,6 @@ ipc.on('electron-notify-click', function (event, winId, notificationObj) {
   }
   let notificationWindow = BrowserWindow.fromId(winId)
   if (notificationWindow && notificationWindow.electronNotifyOnClickFunc) {
-    notificationWindow.clickFunctionFired = true
     let closeFunc = buildCloseNotification(notificationWindow, notificationObj)
     notificationWindow.electronNotifyOnClickFunc({
       event: 'click',
@@ -360,7 +358,6 @@ ipc.on('electron-notify-click', function (event, winId, notificationObj) {
       closeNotification: buildCloseNotificationSafely(closeFunc)
     })
     delete notificationWindow.electronNotifyOnClickFunc
-    closeFunc()
   }
 })
 

--- a/index.js
+++ b/index.js
@@ -359,8 +359,7 @@ ipc.on('electron-notify-click', function (event, winId, notificationObj) {
   let notificationWindow = BrowserWindow.fromId(winId);
   if (notificationWindow && notificationWindow.electronNotifyOnClickFunc) {
     notificationWindow.clickFunctionFired = true;
-
-    let closeFunc = buildCloseNotification(notificationWindow, notificationObj);
+    let closeFunc                         = buildCloseNotification(notificationWindow, notificationObj);
     notificationWindow.electronNotifyOnClickFunc({
       event:             'click',
       id:                notificationObj.id,
@@ -431,7 +430,7 @@ function moveNotificationAnimation (i, done) {
       return done(null, 'done');
     }
     // Move one step down
-    notificationWindow.setPosition(config.firstPos.x, Math.trunc(startY + curStep * step));
+    notificationWindow.setPosition(config.firstPos.x, startY + curStep * step);
     curStep++;
   }, config.animationStepMs);
 }

--- a/index.js
+++ b/index.js
@@ -297,13 +297,14 @@ function buildCloseNotification(notificationWindow, notificationObj, getTimeoutI
       closedNotifications[notificationObj.id] = true
     }
 
-    if (notificationWindow.electronNotifyOnCloseFunc) {
+    if (notificationWindow.electronNotifyOnCloseFunc && !notificationWindow.clickFunctionFired) {
       notificationWindow.electronNotifyOnCloseFunc({
         event: event,
         id: notificationObj.id
       })
       delete notificationWindow.electronNotifyOnCloseFunc
     }
+    delete notificationWindow.clickFunctionFired
 
     // reset content
     notificationWindow.webContents.send('electron-notify-reset')
@@ -351,6 +352,7 @@ ipc.on('electron-notify-click', function (event, winId, notificationObj) {
   }
   let notificationWindow = BrowserWindow.fromId(winId)
   if (notificationWindow && notificationWindow.electronNotifyOnClickFunc) {
+    notificationWindow.clickFunctionFired = true
     let closeFunc = buildCloseNotification(notificationWindow, notificationObj)
     notificationWindow.electronNotifyOnClickFunc({
       event: 'click',
@@ -358,6 +360,7 @@ ipc.on('electron-notify-click', function (event, winId, notificationObj) {
       closeNotification: buildCloseNotificationSafely(closeFunc)
     })
     delete notificationWindow.electronNotifyOnClickFunc
+    closeFunc()
   }
 })
 

--- a/index.js
+++ b/index.js
@@ -1,378 +1,388 @@
-'use strict'
-
-const _ = require('lodash')
-const path = require('path')
-const async = require('async')
-const electron = require('electron')
-const BrowserWindow = electron.BrowserWindow || electron.remote.BrowserWindow
-const ipc = electron.ipcMain || electron.ipcRenderer
+const _             = require('lodash');
+const path          = require('path');
+const async         = require('async');
+const electron      = require('electron');
+const BrowserWindow = electron.BrowserWindow || electron.remote.BrowserWindow;
+const ipc           = electron.ipcMain || electron.ipcRenderer;
 
 // One animation at a time
-const AnimationQueue = function(options) {
-  this.options = options
-  this.queue = []
-  this.running = false
-}
+const AnimationQueue = function (options) {
+  this.options = options;
+  this.queue   = [];
+  this.running = false;
+};
 
-AnimationQueue.prototype.push = function(object) {
+AnimationQueue.prototype.push = function (object) {
   if (this.running) {
-    this.queue.push(object)
-  } else {
-    this.running = true
-    this.animate(object)
+    this.queue.push(object);
   }
-}
+  else {
+    this.running = true;
+    this.animate(object);
+  }
+};
 
-AnimationQueue.prototype.animate = function(object) {
-  let self = this
-  object.func.apply(null, object.args)
-  .then(function() {
+AnimationQueue.prototype.animate = function (object) {
+  let self = this;
+  object.func.apply(null, object.args).then(function () {
     if (self.queue.length > 0) {
       // Run next animation
-      self.animate.call(self, self.queue.shift())
-    } else {
-      self.running = false
+      self.animate.call(self, self.queue.shift());
     }
-  })
-  .catch(function(err) {
-    log('electron-notify encountered an error!')
-    log('Please submit the error stack and code samples to: https://github.com/hankbao/electron-notify/issues')
-    log(err.stack)
-  })
-}
+    else {
+      self.running = false;
+    }
+  }).catch(function (err) {
+    log('electron-notify encountered an error!');
+    log('Please submit the error stack and code samples to: https://github.com/hankbao/electron-notify/issues');
+    log(err.stack);
+  });
+};
 
-AnimationQueue.prototype.clear = function() {
-  this.queue = []
-}
+AnimationQueue.prototype.clear = function () {
+  this.queue = [];
+};
 
 let config = {
-  width: 300,
-  height: 65,
-  padding: 10,
-  borderRadius: 5,
-  displayTime: 5000,
-  animationSteps: 5,
-  animationStepMs: 5,
-  animateInParallel: true,
-  appIcon: null,
-  pathToModule: '',
-  logging: true,
+  width:                 300,
+  height:                65,
+  padding:               10,
+  borderRadius:          5,
+  displayTime:           5000,
+  animationSteps:        5,
+  animationStepMs:       5,
+  animateInParallel:     true,
+  appIcon:               null,
+  pathToModule:          '',
+  logging:               true,
   defaultStyleContainer: {
     backgroundColor: '#f0f0f0',
-    overflow: 'hidden',
-    padding: 8,
-    border: '1px solid #CCC',
-    fontFamily: 'Arial',
-    fontSize: 12,
-    position: 'relative',
-    lineHeight: '15px'
+    overflow:        'hidden',
+    padding:         8,
+    border:          '1px solid #CCC',
+    fontFamily:      'Arial',
+    fontSize:        12,
+    position:        'relative',
+    lineHeight:      '15px'
   },
-  defaultStyleAppIcon: {
-    overflow: 'hidden',
-    float: 'left',
-    height: 40,
-    width: 40,
-    marginRight: 10,
+  defaultStyleAppIcon:   {
+    overflow:    'hidden',
+    float:       'left',
+    height:      40,
+    width:       40,
+    marginRight: 10
   },
-  defaultStyleImage: {
-    overflow: 'hidden',
-    float: 'right',
-    height: 40,
-    width: 40,
-    marginLeft: 10,
+  defaultStyleImage:     {
+    overflow:   'hidden',
+    float:      'right',
+    height:     40,
+    width:      40,
+    marginLeft: 10
   },
-  defaultStyleClose: {
+  defaultStyleClose:     {
     position: 'absolute',
-    top: 1,
-    right: 3,
+    top:      1,
+    right:    3,
     fontSize: 11,
-    color: '#CCC'
+    color:    '#CCC'
   },
-  defaultStyleText: {
-    margin: 0,
+  defaultStyleText:      {
+    margin:   0,
     overflow: 'hidden',
-    cursor: 'default'
+    cursor:   'default'
   },
-  defaultWindow: {
-    alwaysOnTop: true,
-    skipTaskbar: true,
-    resizable: false,
-    show: false,
-    frame: false,
-    transparent: true,
+  defaultWindow:         {
+    alwaysOnTop:      true,
+    skipTaskbar:      true,
+    resizable:        false,
+    show:             false,
+    frame:            false,
+    transparent:      true,
     acceptFirstMouse: true,
-    webPreferences: {
-      preload: path.join(__dirname, 'preload.js'),
+    webPreferences:   {
+      preload:                        path.join(__dirname, 'preload.js'),
       allowDisplayingInsecureContent: true
     }
   },
-  htmlTemplate: '<html>\n'
-  + '<head></head>\n'
-  + '<body style="overflow: hidden; -webkit-user-select: none;" id="body-top">\n'
-  + '<div id="container">\n'
-  + ' <img src="" id="appIcon"/>\n'
-  + ' <img src="" id="image" class="pulse"/>\n'
-  + ' <div id="text">\n'
-  + '   <b id="title"></b>\n'
-  + '   <p id="message"></p>\n'
-  + ' </div>\n'
-  + ' <div id="close">X</div>\n'
-  + '</div>\n'
-  + '</body>\n'
-  + '</html>'
+  htmlTemplate:          '<html>\n'
+                         + '<head></head>\n'
+                         + '<body style="overflow: hidden; -webkit-user-select: none;" id="body-top">\n'
+                         + '<div id="container">\n'
+                         + ' <img src="" id="appIcon"/>\n'
+                         + ' <img src="" id="image" class="pulse"/>\n'
+                         + ' <div id="text">\n'
+                         + '   <b id="title"></b>\n'
+                         + '   <p id="message"></p>\n'
+                         + ' </div>\n'
+                         + ' <div id="close">X</div>\n'
+                         + '</div>\n'
+                         + '</body>\n'
+                         + '</html>'
+};
+
+function setConfig (customConfig) {
+  config = _.defaults(customConfig, config);
+  calcDimensions();
 }
 
-function setConfig(customConfig) {
-  config = _.defaults(customConfig, config)
-  calcDimensions()
-}
-
-function updateTemplatePath() {
-  let templatePath = path.join(__dirname, 'notification.html')
+function updateTemplatePath () {
+  let templatePath = path.join(__dirname, 'notification.html');
   // Tricky stuff, sometimes this doesn't work,
   // especially when webpack is involved.
   // Check if we have a file at that location
   try {
-    require('fs').statSync(templatePath).isFile()
+    require('fs').statSync(templatePath).isFile();
   } catch (err) {
-    log('electron-notify: Could not find template ("' + templatePath + '").')
-    log('electron-notify: To use a different template you need to correct the config.templatePath or simply adapt config.htmlTemplate')
-     // TODO: No file => should we create our own temporary notification.html?
+    log('electron-notify: Could not find template ("' + templatePath + '").');
+    log(
+      'electron-notify: To use a different template you need to correct the config.templatePath or simply adapt config.htmlTemplate');
+    // TODO: No file => should we create our own temporary notification.html?
   }
-  config.templatePath = 'file://' + templatePath
-  return config.templatePath
+  config.templatePath = 'file://' + templatePath;
+  return config.templatePath;
 }
 
-function getTemplatePath() {
+function getTemplatePath () {
   if (config.templatePath === undefined) {
-    return updateTemplatePath()
+    return updateTemplatePath();
   }
-  return config.templatePath
+  return config.templatePath;
 }
 
-function setTemplatePath(path) {
-  config.templatePath = path
+function setTemplatePath (path) {
+  config.templatePath = path;
 }
 
-let nextInsertPos = {}
-function calcDimensions() {
+let nextInsertPos = {};
+
+function calcDimensions () {
   // Calc totalHeight & totalWidth
-  config.totalHeight = config.height + config.padding
-  config.totalWidth = config.width + config.padding
+  config.totalHeight = config.height + config.padding;
+  config.totalWidth  = config.width + config.padding;
 
   // Calc pos of first notification:
   config.firstPos = {
     x: config.lowerRightCorner.x - config.totalWidth,
     y: config.lowerRightCorner.y - config.totalHeight
-  }
+  };
 
   // Set nextInsertPos
-  nextInsertPos.x = config.firstPos.x
-  nextInsertPos.y = config.firstPos.y
+  nextInsertPos.x = config.firstPos.x;
+  nextInsertPos.y = config.firstPos.y;
 }
 
-function setupConfig() {
+function setupConfig () {
   // Use primary display only
-  let display = electron.screen.getPrimaryDisplay()
+  let display = electron.screen.getPrimaryDisplay();
 
   // Display notifications starting from lower right corner
   // Calc lower right corner
-  config.lowerRightCorner = {}
-  config.lowerRightCorner.x = display.bounds.x + display.workArea.x + display.workAreaSize.width
-  config.lowerRightCorner.y = display.bounds.y + display.workArea.y + display.workAreaSize.height
+  config.lowerRightCorner   = {};
+  config.lowerRightCorner.x = display.bounds.x + display.workArea.x + display.workAreaSize.width;
+  config.lowerRightCorner.y = display.bounds.y + display.workArea.y + display.workAreaSize.height;
 
-  calcDimensions()
+  calcDimensions();
 
   // Maximum amount of Notifications we can show:
-  config.maxVisibleNotifications = Math.floor(display.workAreaSize.height / config.totalHeight)
-  config.maxVisibleNotifications = config.maxVisibleNotifications > 7 ? 7 : config.maxVisibleNotifications
+  config.maxVisibleNotifications = Math.floor(display.workAreaSize.height / config.totalHeight);
+  config.maxVisibleNotifications = config.maxVisibleNotifications > 7 ? 7 : config.maxVisibleNotifications;
 }
 
-setupConfig()
+setupConfig();
 
 // Array of windows with currently showing notifications
-let activeNotifications = []
+let activeNotifications = [];
 
 // Recycle windows
-let inactiveWindows = []
+let inactiveWindows = [];
 
 // If we cannot show all notifications, queue them
-let notificationQueue = []
+let notificationQueue = [];
 
-// To prevent executing mutliple animations at once
-let animationQueue = new AnimationQueue()
+// To prevent executing multiple animations at once
+let animationQueue = new AnimationQueue();
 
 // To prevent double-close notification window
-let closedNotifications = {}
+let closedNotifications = {};
 
 // Give each notification a unique id
-let latestID = 0
+let latestID = 0;
 
-function notify(notification) {
+function notify (notification) {
   // Is it an object and only one argument?
   if (arguments.length === 1 && typeof notification === 'object') {
     // Use object instead of supplied parameters
-    notification.id = latestID
-    latestID++
+    notification.id = latestID;
+    latestID++;
     animationQueue.push({
       func: showNotification,
-      args: [ notification ]
-    })
-    return notification.id
-  } else {
+      args: [notification]
+    });
+    return notification.id;
+  }
+  else {
     // Since 1.0.0 all notification parameters need to be passed
     // as object.
-    log('electron-notify: ERROR notify() only accepts a single object with notification parameters.')
+    log('electron-notify: ERROR notify() only accepts a single object with notification parameters.');
   }
 }
 
-function showNotification(notificationObj) {
-  return new Promise(function(resolve) {
+function showNotification (notificationObj) {
+  return new Promise(function (resolve) {
     // Can we show it?
     if (activeNotifications.length < config.maxVisibleNotifications) {
       // Get inactiveWindow or create new:
-      getWindow().then(function(notificationWindow) {
+      getWindow().then(function (notificationWindow) {
         // Move window to position
-        calcInsertPos()
-        notificationWindow.setPosition(nextInsertPos.x, nextInsertPos.y)
+        calcInsertPos();
+        notificationWindow.setPosition(nextInsertPos.x, nextInsertPos.y);
 
         // Add to activeNotifications
-        activeNotifications.push(notificationWindow)
+        activeNotifications.push(notificationWindow);
 
         // Display time per notification basis.
-        let displayTime = notificationObj.displayTime ? notificationObj.displayTime : config.displayTime
+        let displayTime = notificationObj.displayTime ? notificationObj.displayTime : config.displayTime;
 
         // Set timeout to hide notification
-        let timeoutId
-        let closeFunc = buildCloseNotification(notificationWindow, notificationObj, function() {
-          return timeoutId
-        })
-        let closeNotificationSafely = buildCloseNotificationSafely(closeFunc)
-        timeoutId = setTimeout(function() {
-          closeNotificationSafely('timeout')
-        }, displayTime)
+        let timeoutId;
+        let closeFunc               = buildCloseNotification(notificationWindow, notificationObj, function () {
+          return timeoutId;
+        });
+        let closeNotificationSafely = buildCloseNotificationSafely(closeFunc);
+        timeoutId                   = setTimeout(function () {
+          closeNotificationSafely('timeout');
+        }, displayTime);
 
         // Trigger onShowFunc if existent
         if (notificationObj.onShowFunc) {
           notificationObj.onShowFunc({
-            event: 'show',
-            id: notificationObj.id,
+            event:             'show',
+            id:                notificationObj.id,
             closeNotification: closeNotificationSafely
-          })
+          });
         }
 
         // Save onClickFunc in notification window
         if (notificationObj.onClickFunc) {
-          notificationWindow.electronNotifyOnClickFunc = notificationObj.onClickFunc
-        } else {
-          delete notificationWindow.electronNotifyOnClickFunc
+          notificationWindow.electronNotifyOnClickFunc = notificationObj.onClickFunc;
+        }
+        else {
+          delete notificationWindow.electronNotifyOnClickFunc;
         }
 
         if (notificationObj.onCloseFunc) {
-          notificationWindow.electronNotifyOnCloseFunc = notificationObj.onCloseFunc
-        } else {
-          delete notificationWindow.electronNotifyOnCloseFunc
+          notificationWindow.electronNotifyOnCloseFunc = notificationObj.onCloseFunc;
+        }
+        else {
+          delete notificationWindow.electronNotifyOnCloseFunc;
         }
 
         // Set contents, ...
-        notificationWindow.webContents.send('electron-notify-set-contents', notificationObj)
+        notificationWindow.webContents.send('electron-notify-set-contents', notificationObj);
         // Show window
-        notificationWindow.showInactive()
-        resolve(notificationWindow)
-      })
-    } else { // Add to notificationQueue
-      notificationQueue.push(notificationObj)
-      resolve()
+        notificationWindow.showInactive();
+        resolve(notificationWindow);
+      });
     }
-  })
+    else { // Add to notificationQueue
+      notificationQueue.push(notificationObj);
+      resolve();
+    }
+  });
 }
 
 // Close notification function
-function buildCloseNotification(notificationWindow, notificationObj, getTimeoutId) {
-  return function(event) {
+function buildCloseNotification (notificationWindow, notificationObj, getTimeoutId) {
+  return function (event) {
     if (closedNotifications[notificationObj.id]) {
-      delete closedNotifications[notificationObj.id]
-      return new Promise(function(exitEarly) { exitEarly() })
-    } else {
-      closedNotifications[notificationObj.id] = true
+      delete closedNotifications[notificationObj.id];
+      return new Promise(function (exitEarly) { exitEarly(); });
+    }
+    else {
+      closedNotifications[notificationObj.id] = true;
     }
 
-    if (notificationWindow.electronNotifyOnCloseFunc) {
+    if (notificationWindow.electronNotifyOnCloseFunc && !notificationWindow.clickFunctionFired) {
       notificationWindow.electronNotifyOnCloseFunc({
         event: event,
-        id: notificationObj.id
-      })
-      delete notificationWindow.electronNotifyOnCloseFunc
+        id:    notificationObj.id
+      });
+      delete notificationWindow.electronNotifyOnCloseFunc;
     }
+    delete notificationWindow.clickFunctionFired;
 
     // reset content
-    notificationWindow.webContents.send('electron-notify-reset')
+    notificationWindow.webContents.send('electron-notify-reset');
     if (getTimeoutId && typeof getTimeoutId === 'function') {
-      let timeoutId = getTimeoutId()
-      clearTimeout(timeoutId)
+      let timeoutId = getTimeoutId();
+      clearTimeout(timeoutId);
     }
 
     // Recycle window
-    let pos = activeNotifications.indexOf(notificationWindow)
-    activeNotifications.splice(pos, 1)
-    inactiveWindows.push(notificationWindow)
+    let pos = activeNotifications.indexOf(notificationWindow);
+    activeNotifications.splice(pos, 1);
+    inactiveWindows.push(notificationWindow);
 
     // Hide notification
-    notificationWindow.hide()
+    notificationWindow.hide();
 
-    checkForQueuedNotifications()
+    checkForQueuedNotifications();
 
     // Move notifications down
-    return moveOneDown(pos)
-  }
+    return moveOneDown(pos);
+  };
 }
 
 // Always add to animationQueue to prevent erros (e.g. notification
 // got closed while it was moving will produce an error)
-function buildCloseNotificationSafely(closeFunc) {
-  return function(reason) {
-    if (reason === undefined)
-    reason = 'closedByAPI'
+function buildCloseNotificationSafely (closeFunc) {
+  return function (reason) {
+    if (reason === undefined) {
+      reason = 'closedByAPI';
+    }
     animationQueue.push({
       func: closeFunc,
-      args: [ reason ]
-    })
-  }
+      args: [reason]
+    });
+  };
 }
 
 ipc.on('electron-notify-close', function (event, winId, notificationObj) {
-  let closeFunc = buildCloseNotification(BrowserWindow.fromId(winId), notificationObj)
-  buildCloseNotificationSafely(closeFunc)('close')
-})
+  let closeFunc = buildCloseNotification(BrowserWindow.fromId(winId), notificationObj);
+  buildCloseNotificationSafely(closeFunc)('close');
+});
 
 ipc.on('electron-notify-click', function (event, winId, notificationObj) {
   if (notificationObj.url) {
-    electron.shell.openExternal(notificationObj.url)
+    electron.shell.openExternal(notificationObj.url);
   }
-  let notificationWindow = BrowserWindow.fromId(winId)
+  let notificationWindow = BrowserWindow.fromId(winId);
   if (notificationWindow && notificationWindow.electronNotifyOnClickFunc) {
-    let closeFunc = buildCloseNotification(notificationWindow, notificationObj)
+    notificationWindow.clickFunctionFired = true;
+
+    let closeFunc = buildCloseNotification(notificationWindow, notificationObj);
     notificationWindow.electronNotifyOnClickFunc({
-      event: 'click',
-      id: notificationObj.id,
+      event:             'click',
+      id:                notificationObj.id,
       closeNotification: buildCloseNotificationSafely(closeFunc)
-    })
-    delete notificationWindow.electronNotifyOnClickFunc
+    });
+    delete notificationWindow.electronNotifyOnClickFunc;
+    closeFunc();
   }
-})
+});
 
 /*
 * Checks for queued notifications and add them
 * to AnimationQueue if possible
 */
-function checkForQueuedNotifications() {
+function checkForQueuedNotifications () {
   if (notificationQueue.length > 0 &&
     activeNotifications.length < config.maxVisibleNotifications) {
     // Add new notification to animationQueue
     animationQueue.push({
       func: showNotification,
-      args: [ notificationQueue.shift() ]
-    })
+      args: [notificationQueue.shift()]
+    });
   }
 }
 
@@ -382,56 +392,56 @@ function checkForQueuedNotifications() {
 *
 * @param  {int} startPos
 */
-function moveOneDown(startPos) {
-  return new Promise(function(resolve) {
+function moveOneDown (startPos) {
+  return new Promise(function (resolve) {
     if (startPos >= activeNotifications || startPos === -1) {
-      resolve()
-      return
+      resolve();
+      return;
     }
     // Build array with index of affected notifications
-    let notificationPosArray = []
+    let notificationPosArray = [];
     for (let i = startPos; i < activeNotifications.length; i++) {
-      notificationPosArray.push(i)
+      notificationPosArray.push(i);
     }
     // Start to animate all notifications at once or in parallel
-    let asyncFunc = async.map // Best performance
+    let asyncFunc = async.map; // Best performance
     if (config.animateInParallel === false) {
-      asyncFunc = async.mapSeries // Sluggish
+      asyncFunc = async.mapSeries; // Sluggish
     }
-    asyncFunc(notificationPosArray, moveNotificationAnimation, function() {
-      resolve()
-    })
-  })
+    asyncFunc(notificationPosArray, moveNotificationAnimation, function () {
+      resolve();
+    });
+  });
 }
 
-function moveNotificationAnimation(i, done) {
+function moveNotificationAnimation (i, done) {
   // Get notification to move
-  let notificationWindow = activeNotifications[i]
+  let notificationWindow = activeNotifications[i];
   // Calc new y position
-  let newY = config.lowerRightCorner.y - config.totalHeight * (i + 1)
+  let newY               = config.lowerRightCorner.y - config.totalHeight * (i + 1);
   // Get startPos, calc step size and start animationInterval
-  let startY = notificationWindow.getPosition()[1]
-  let step = (newY - startY) / config.animationSteps
-  let curStep = 1
-  let animationInterval = setInterval(function() {
+  let startY             = notificationWindow.getPosition()[1];
+  let step               = (newY - startY) / config.animationSteps;
+  let curStep            = 1;
+  let animationInterval  = setInterval(function () {
     // Abort condition
     if (curStep === config.animationSteps) {
-      notificationWindow.setPosition(config.firstPos.x, newY)
-      clearInterval(animationInterval)
-      return done(null, 'done')
+      notificationWindow.setPosition(config.firstPos.x, newY);
+      clearInterval(animationInterval);
+      return done(null, 'done');
     }
     // Move one step down
-    notificationWindow.setPosition(config.firstPos.x, Math.trunc(startY + curStep * step))
-    curStep++
-  }, config.animationStepMs)
+    notificationWindow.setPosition(config.firstPos.x, Math.trunc(startY + curStep * step));
+    curStep++;
+  }, config.animationStepMs);
 }
 
 /*
 * Find next possible insert position (on top)
 */
-function calcInsertPos() {
+function calcInsertPos () {
   if (activeNotifications.length < config.maxVisibleNotifications) {
-    nextInsertPos.y = config.lowerRightCorner.y - config.totalHeight * (activeNotifications.length + 1)
+    nextInsertPos.y = config.lowerRightCorner.y - config.totalHeight * (activeNotifications.length + 1);
   }
 }
 
@@ -440,52 +450,53 @@ function calcInsertPos() {
 * create a new window
 * @return {Window}
 */
-function getWindow() {
-  return new Promise(function(resolve) {
-    let notificationWindow
+function getWindow () {
+  return new Promise(function (resolve) {
+    let notificationWindow;
     // Are there still inactiveWindows?
     if (inactiveWindows.length > 0) {
-      notificationWindow = inactiveWindows.pop()
-      resolve(notificationWindow)
-    } else { // Or create a new window
-      let windowProperties = config.defaultWindow
-      windowProperties.width = config.width
-      windowProperties.height = config.height
-      notificationWindow = new BrowserWindow(windowProperties)
-      notificationWindow.setVisibleOnAllWorkspaces(true)
-      notificationWindow.loadURL(getTemplatePath())
-      notificationWindow.webContents.on('did-finish-load', function() {
-        // Done
-        notificationWindow.webContents.send('electron-notify-load-config', config)
-        resolve(notificationWindow)
-      })
+      notificationWindow = inactiveWindows.pop();
+      resolve(notificationWindow);
     }
-  })
+    else { // Or create a new window
+      let windowProperties    = config.defaultWindow;
+      windowProperties.width  = config.width;
+      windowProperties.height = config.height;
+      notificationWindow      = new BrowserWindow(windowProperties);
+      notificationWindow.setVisibleOnAllWorkspaces(true);
+      notificationWindow.loadURL(getTemplatePath());
+      notificationWindow.webContents.on('did-finish-load', function () {
+        // Done
+        notificationWindow.webContents.send('electron-notify-load-config', config);
+        resolve(notificationWindow);
+      });
+    }
+  });
 }
 
-function closeAll() {
+function closeAll () {
   // Clear out animation Queue and close windows
-  animationQueue.clear()
-  _.forEach(activeNotifications, function(window) {
-    window.close()
-  })
-  _.forEach(inactiveWindows, function(window) {
-    window.close()
-  })
+  animationQueue.clear();
+  _.forEach(activeNotifications, function (window) {
+    window.close();
+  });
+  _.forEach(inactiveWindows, function (window) {
+    window.close();
+  });
   // Reset certain vars
-  nextInsertPos = {}
-  activeNotifications = []
-  inactiveWindows = []
+  nextInsertPos       = {};
+  activeNotifications = [];
+  inactiveWindows     = [];
 }
 
-function log() {
+function log () {
   if (config.logging === true) {
-    console.log.apply(console, arguments)
+    console.log.apply(console, arguments);
   }
 }
 
-module.exports.notify = notify
-module.exports.setConfig = setConfig
-module.exports.getTemplatePath = getTemplatePath
-module.exports.setTemplatePath = setTemplatePath
-module.exports.closeAll = closeAll
+module.exports.notify          = notify;
+module.exports.setConfig       = setConfig;
+module.exports.getTemplatePath = getTemplatePath;
+module.exports.setTemplatePath = setTemplatePath;
+module.exports.closeAll        = closeAll;

--- a/notification.html
+++ b/notification.html
@@ -1,9 +1,9 @@
 <html>
 <head></head>
-<body style='overflow: hidden; -webkit-user-select: none;'>
+<body style='overflow: hidden; -webkit-user-select: none;' id="body-top">
 <div id="container">
 	<img src="" id="appIcon" />
-	<img src="" id="image" />
+	<img src="" id="image" class="pulse"/>
 	<div id="text">
 		<b id="title"></b>
 		<p id="message"></p>


### PR DESCRIPTION
This fixes the issue where the close timer would fire the close event on a null window id. The window id is null when the user fires the on-click close event. This makes it so two close events no longer happens. 

This also changes some styles for the notification window. It now comes in with a little bit of an animation.

TODO: We should also look into why the window doesn't actually close with the onclose click event. If you close the window by clicking the window disappears, but the window is still technically there until the window display time reaches its interval. You can see this by making more than one notification go off and closing 1 of them. The second one will appear after the first one even though the first one is no longer there.